### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/adiazz/d073a85d-b75a-4881-8bd5-cd0244bcfa4c/a360d2cf-855d-4b0d-8709-70cb513fab91/_apis/work/boardbadge/113cbaec-fdd5-4b1d-95aa-30fd125c6444)](https://dev.azure.com/adiazz/d073a85d-b75a-4881-8bd5-cd0244bcfa4c/_boards/board/t/a360d2cf-855d-4b0d-8709-70cb513fab91/Microsoft.RequirementCategory)
 # argocd-samples
 argocd-sample


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/adiazz/d073a85d-b75a-4881-8bd5-cd0244bcfa4c/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.